### PR TITLE
fix: initialization of user data

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -51,6 +51,9 @@ func attrToSentryEvent(attr slog.Attr, event *sentry.Event) {
 			if err, ok := attr.Value.Any().(error); ok {
 				event.Exception = buildExceptions(err)
 			} else {
+				if event.User.Data == nil {
+					event.User.Data = map[string]string{}
+				}
 				event.User.Data[errorKey] = slogcommon.AnyValueToString(v)
 			}
 		}

--- a/version.go
+++ b/version.go
@@ -1,4 +1,6 @@
 package slogsentry
 
 const name = "samber/slog-sentry"
+
+// nolint
 const version = "VERSION" // replaced by .github/workflows/release.yml


### PR DESCRIPTION
Since error is already formatted by
default converter, it's not an error
anymore. Event.User.Data will be nil
because it's the first time used. 
Handle is done under try so it will be doing
nothing silently if there is an error attribute
in the log line.