### PR TITLE
Handle fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The following attributes are interpreted by `slogsentry.DefaultConverter`:
 | "user"           | group (see below) |                 |
 | "error"          | any               | `error`         |
 | "request"        | any               | `*http.Request` |
+| "fingerprint"    | any               | `[]string`      |
 | other attributes | *                 |                 |
 
 Other attributes will be injected in `context` Sentry field.

--- a/converter.go
+++ b/converter.go
@@ -107,6 +107,10 @@ func attrToSentryEvent(attr slog.Attr, event *sentry.Event) {
 				}
 			}
 		}
+	case k == "fingerprint" && kind == slog.KindAny:
+		if fingerprint, ok := v.Any().([]string); ok {
+			event.Fingerprint = fingerprint
+		}
 	case kind == slog.KindGroup:
 		event.Contexts[k] = slogcommon.AttrsToMap(v.Group()...)
 	default:

--- a/converter_test.go
+++ b/converter_test.go
@@ -162,6 +162,10 @@ func TestAttrToSentryEvent(t *testing.T) {
 				}},
 			},
 		},
+		"fingerprint": {
+			attr:     slog.Attr{Key: "fingerprint", Value: slog.AnyValue([]string{"value1", "value2"})},
+			expected: &sentry.Event{Fingerprint: []string{"value1", "value2"}},
+		},
 	}
 
 	for name, tc := range tests {
@@ -177,6 +181,7 @@ func TestAttrToSentryEvent(t *testing.T) {
 			assert.Equal(t, tc.expected.Transaction, event.Transaction)
 			assert.Equal(t, tc.expected.User, event.User)
 			assert.Equal(t, tc.expected.Request, event.Request)
+			assert.Equal(t, tc.expected.Fingerprint, event.Fingerprint)
 			if len(tc.expected.Tags) == 0 {
 				assert.Empty(t, event.Tags)
 			} else {


### PR DESCRIPTION
This pull request introduces support for handling the fingerprint attribute in the slog-to-Sentry event conversion process.

- Added logic in attrToSentryEvent to recognize the "fingerprint" key and assign its value to the Sentry event's Fingerprint field.
- Implemented the handleFingerprint function to process the attribute when it is a []string.
- Added corresponding test cases to ensure correct behavior.

This enhancement allows users to specify custom fingerprints via slog attributes, enabling more flexible event grouping in Sentry.

This is the same suggestion as the following:
- https://github.com/getsentry/sentry-go/pull/1039